### PR TITLE
Update mega_alerts.py

### DIFF
--- a/mega_alerts.py
+++ b/mega_alerts.py
@@ -209,7 +209,7 @@ class Alerts(QThread):
                 # check if token price is below threshold durring commodity run
                 if mega_data.TOKEN_PRICE:
                     token_price = mega_data.get_wow_token_price()
-                    if mega_data.TOKEN_PRICE is not None and mega_data.TOKEN_PRICE > 0:
+                    if token_price and token_price < mega_data.TOKEN_PRICE:
                         token_embed = create_embed(
                             f"WoW Token Alert - {mega_data.REGION}",
                             f"**Token Price:** {token_price:,} gold\n**Threshold:** {mega_data.TOKEN_PRICE:,} gold\n**Region:** {mega_data.REGION}",


### PR DESCRIPTION
I think the logic was incorrect, this seems to fix it to only alert when below the defined threshold in mega_data.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated token price alert logic to trigger only when the current token price falls below the configured threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->