### PR TITLE
Update item_names.json

### DIFF
--- a/StaticData/item_names.json
+++ b/StaticData/item_names.json
@@ -28925,7 +28925,7 @@
   "224834": "Exquisite Weavercloth Bolt",
   "225218": "Echoing Fragment: Hallowfall",
   "225219": "Echoing Fragment: The Ringing Deeps",
-  "225236": "Princess Pumpkin",
+  "225236": "Echoing Fragment: Isle of Dorn",
   "225237": "Echoing Fragment: Azj-Kahet",
   "225241": "Refurbished Tinker: Alarm-O-Turret",
   "225242": "Refurbished Tinker: Plane Displacer",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the displayed name for item ID 225236 to “Echoing Fragment: Isle of Dorn” (was “Princess Pumpkin”), ensuring accurate labeling across lists, tooltips, search results, and filters.

* **Chores**
  * Standardized data formatting with a trailing newline for consistency. No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->